### PR TITLE
Improve app accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ export function Altair() {
 
 ## development
 
+### Keyboard Shortcuts
+
+Use `Ctrl+/` to view all available shortcuts in the app. Common ones include:
+
+- `Ctrl+B` Toggle the side panel
+- `Ctrl+1` Show all logs
+- `Ctrl+2` Show conversations
+- `Ctrl+3` Show tool logs
+- `Ctrl+K` Focus the log search
+- `Ctrl+E` Focus the message input
+- `Ctrl+Enter` Send a message
+
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 Project consists of:
 
@@ -122,5 +134,9 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+### `npm run a11y`
+
+Runs an accessibility scan using [axe-core](https://github.com/dequelabs/axe-core).
 
 _This is an experiment showcasing the Live API, not an official Google product. We’ll do our best to support and maintain this experiment but your mileage may vary. We encourage open sourcing projects as a way of learning from each other. Please respect our and other creators' rights, including copyright and trademark rights when present, when sharing these works and creating derivative work. If you want more info on Google's policy, you can find that [here](https://developers.google.com/terms/site-policies)._

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "a11y": "react-scripts test --runTestsByPath src/accessibility.test.tsx",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -57,6 +58,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "jest-axe": "^7.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   },

--- a/src/accessibility.test.tsx
+++ b/src/accessibility.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import App from "./App";
+
+expect.extend(toHaveNoViolations);
+
+test("app should have no accessibility violations", async () => {
+  const { container } = render(<App />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});

--- a/src/components/logger/Logger.tsx
+++ b/src/components/logger/Logger.tsx
@@ -370,7 +370,7 @@ export default function Logger({ filter = "none", search = "" }: LoggerProps) {
     return () => ro.disconnect();
   }, []);
 
-  const Row = ({ index, style }: { index: number; style: React.CSSProperties }) => {
+  const Row = memo(({ index, style }: { index: number; style: React.CSSProperties }) => {
     const log = filteredLogs[index];
     const rowRef = useCallback(
       (el: HTMLLIElement | null) => {
@@ -387,7 +387,7 @@ export default function Logger({ filter = "none", search = "" }: LoggerProps) {
         onContextMenu={onContextMenu(log)}
       />
     );
-  };
+  });
 
   return (
     <div className="logger" ref={containerRef}>

--- a/src/components/settings-dialog/SettingsDialog.tsx
+++ b/src/components/settings-dialog/SettingsDialog.tsx
@@ -91,6 +91,9 @@ You are a ${genderText} TikTok Live Selling Affiliate speaking in ${language}. Y
       />
       <dialog
         className={cn("dialog", { open, closing })}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-title"
         onAnimationEnd={() => {
           if (closing) {
             setClosing(false);
@@ -98,7 +101,10 @@ You are a ${genderText} TikTok Live Selling Affiliate speaking in ${language}. Y
           }
         }}
       >
-        <Panel className={`dialog-container ${connected ? "disabled" : ""}`}>
+        <Panel
+          className={`dialog-container ${connected ? "disabled" : ""}`}
+          title={<h3 id="settings-title">Settings</h3>}
+        >
           {connected && (
             <div className="connected-indicator">
               <p>


### PR DESCRIPTION
## Summary
- document keyboard shortcuts
- add script and tests for axe accessibility scanning
- enhance SettingsDialog ARIA labels
- memoize Logger row component for performance

## Testing
- `npm test --silent`
- `npm run a11y --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c3c0e18ec8327a7986e067d16cc63